### PR TITLE
Removed address filed and find button from the contact details screen

### DIFF
--- a/app/src/main/java/it/bz/noi/community/ui/meet/ContactDetailsFragment.kt
+++ b/app/src/main/java/it/bz/noi/community/ui/meet/ContactDetailsFragment.kt
@@ -106,27 +106,6 @@ class ContactDetailsFragment : Fragment() {
 				phone.root.isVisible = false
 				binding.call.isVisible = false
 			}
-
-			if (company?.address != null) {
-				val formattedAddress = company.address.replace("\r\n", ", ")
-
-				address.apply {
-					fieldLbl.text = getString(R.string.label_address)
-					fieldValue.text = formattedAddress
-					root.setOnClickListener {
-						copyToClipboard("address_copied", formattedAddress)
-						showCheckmark(address.copyValueIcon)
-					}
-				}
-
-				binding.find.setOnClickListener {
-					requireContext().findOnMaps(formattedAddress)
-				}
-			} else {
-				address.root.isVisible = false
-				binding.find.isVisible = false
-			}
-
 		}
 
 		(requireActivity() as AppCompatActivity).supportActionBar?.title = contact.fullName

--- a/app/src/main/res/layout/fragment_contact_details.xml
+++ b/app/src/main/res/layout/fragment_contact_details.xml
@@ -56,6 +56,7 @@ SPDX-License-Identifier: CC0-1.0
 
 					<TextView
 						android:id="@+id/contactName"
+						style="?attr/textAppearanceHeadline1"
 						android:layout_width="match_parent"
 						android:layout_height="wrap_content"
 						android:layout_marginStart="@dimen/default_margin"
@@ -64,11 +65,11 @@ SPDX-License-Identifier: CC0-1.0
 						android:textColor="@color/primary_color"
 						app:layout_constraintStart_toStartOf="parent"
 						app:layout_constraintTop_toBottomOf="@id/contactIconCardView"
-						style="?attr/textAppearanceHeadline1"
 						tools:text="Mario\nRossi" />
 
 					<TextView
 						android:id="@+id/companyName"
+						style="?attr/textAppearanceHeadline5"
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"
 						android:layout_marginStart="@dimen/default_margin"
@@ -77,7 +78,6 @@ SPDX-License-Identifier: CC0-1.0
 						android:textColor="@color/primary_color"
 						app:layout_constraintStart_toStartOf="parent"
 						app:layout_constraintTop_toBottomOf="@id/contactName"
-						style="?attr/textAppearanceHeadline5"
 						tools:text="NOI AG" />
 
 					<com.google.android.material.card.MaterialCardView
@@ -95,13 +95,13 @@ SPDX-License-Identifier: CC0-1.0
 
 						<TextView
 							android:id="@+id/contactIcon"
+							style="?attr/textAppearanceSubtitle1"
 							android:layout_width="match_parent"
 							android:layout_height="match_parent"
 							android:gravity="center"
 							android:padding="4dp"
 							android:textAlignment="center"
 							android:textColor="@color/primary_color"
-							style="?attr/textAppearanceSubtitle1"
 							tools:text="MR" />
 					</com.google.android.material.card.MaterialCardView>
 
@@ -127,25 +127,17 @@ SPDX-License-Identifier: CC0-1.0
 				app:layout_constraintStart_toStartOf="parent"
 				app:layout_constraintTop_toBottomOf="@id/email" />
 
-			<include
-				android:id="@+id/address"
-				layout="@layout/contact_detail_field"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_marginTop="@dimen/default_margin"
-				app:layout_constraintStart_toStartOf="parent"
-				app:layout_constraintTop_toBottomOf="@id/phone" />
-
 		</androidx.constraintlayout.widget.ConstraintLayout>
 
 	</androidx.core.widget.NestedScrollView>
 
-	<androidx.constraintlayout.widget.ConstraintLayout
+	<LinearLayout
 		android:id="@+id/footer"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:background="@color/tertiary_background_color"
 		android:elevation="20dp"
+		android:orientation="horizontal"
 		android:padding="@dimen/default_margin"
 		app:layout_constraintBottom_toBottomOf="parent"
 		app:layout_constraintEnd_toEndOf="parent"
@@ -156,13 +148,9 @@ SPDX-License-Identifier: CC0-1.0
 			style="@style/ThemeOverlay.NOI.OutlinedButton"
 			android:layout_width="0dp"
 			android:layout_height="wrap_content"
+			android:layout_weight="1"
 			android:text="@string/btn_mail"
-			app:icon="@drawable/ic_mail"
-			app:layout_constraintBottom_toBottomOf="parent"
-			app:layout_constraintEnd_toStartOf="@+id/call"
-			app:layout_constraintHorizontal_bias="0.5"
-			app:layout_constraintStart_toStartOf="parent"
-			app:layout_constraintTop_toTopOf="parent" />
+			app:icon="@drawable/ic_mail" />
 
 		<com.google.android.material.button.MaterialButton
 			android:id="@+id/call"
@@ -170,28 +158,10 @@ SPDX-License-Identifier: CC0-1.0
 			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:layout_marginStart="7dp"
+			android:layout_weight="1"
 			android:text="@string/btn_call"
-			app:icon="@drawable/ic_phone"
-			app:layout_constraintBottom_toBottomOf="parent"
-			app:layout_constraintEnd_toStartOf="@+id/find"
-			app:layout_constraintHorizontal_bias="0.5"
-			app:layout_constraintStart_toEndOf="@+id/sendEmail"
-			app:layout_constraintTop_toTopOf="parent" />
-
-		<com.google.android.material.button.MaterialButton
-			android:id="@+id/find"
-			style="@style/ThemeOverlay.NOI.OutlinedButton"
-			android:layout_width="0dp"
-			android:layout_height="wrap_content"
-			android:layout_marginStart="7dp"
-			android:text="@string/btn_find"
-			app:icon="@drawable/ic_find_on_maps"
-			app:layout_constraintBottom_toBottomOf="parent"
-			app:layout_constraintEnd_toEndOf="parent"
-			app:layout_constraintHorizontal_bias="0.5"
-			app:layout_constraintStart_toEndOf="@+id/call"
-			app:layout_constraintTop_toTopOf="parent" />
-	</androidx.constraintlayout.widget.ConstraintLayout>
+			app:icon="@drawable/ic_phone" />
+	</LinearLayout>
 
 	<ProgressBar
 		android:id="@+id/loader"

--- a/app/src/main/res/raw/filters.json
+++ b/app/src/main/res/raw/filters.json
@@ -3,6 +3,8 @@
 		"Id": "sport",
 		"Key": "Sport",
 		"Type": "CustomTagging",
+		"Parent": "EventType",
+		"Bitmask": 0,
 		"TypeDesc": {
 			"de": "Sport",
 			"en": "Sport",
@@ -13,6 +15,8 @@
 		"Id": "noicommunity",
 		"Key": "NOI Community",
 		"Type": "CustomTagging",
+		"Parent": "EventType",
+		"Bitmask": 0,
 		"TypeDesc": {
 			"de": "NOI Community",
 			"en": "NOI Community",
@@ -20,19 +24,11 @@
 		}
 	},
 	{
-		"Id": "alpine",
-		"Key": "Alpine",
-		"Type": "TechnologyFields",
-		"TypeDesc": {
-			"de": "Alpine",
-			"en": "Alpine",
-			"it": "Alpine"
-		}
-	},
-	{
 		"Id": "automotiveautomation",
 		"Key": "Automotive/Automation",
 		"Type": "TechnologyFields",
+		"Parent": "",
+		"Bitmask": 0,
 		"TypeDesc": {
 			"de": "Automotive / Automation",
 			"en": "Automotive / Automation",
@@ -43,6 +39,8 @@
 		"Id": "digital",
 		"Key": "Digital",
 		"Type": "TechnologyFields",
+		"Parent": "",
+		"Bitmask": 0,
 		"TypeDesc": {
 			"de": "Digital",
 			"en": "Digital",
@@ -50,23 +48,39 @@
 		}
 	},
 	{
-		"Id": "food",
-		"Key": "Food",
-		"Type": "TechnologyFields",
-		"TypeDesc": {
-			"de": "Food",
-			"en": "Food",
-			"it": "Food"
-		}
-	},
-	{
 		"Id": "green",
 		"Key": "Green",
 		"Type": "TechnologyFields",
+		"Parent": "",
+		"Bitmask": 0,
 		"TypeDesc": {
 			"de": "Green",
 			"en": "Green",
 			"it": "Green"
+		}
+	},
+	{
+		"Id": "publicengagement",
+		"Key": "Public Engagement",
+		"Type": "CustomTagging",
+		"Parent": "EventType",
+		"Bitmask": 0,
+		"TypeDesc": {
+			"de": "Public Engagement",
+			"en": "Public Engagement",
+			"it": "Public Engagement"
+		}
+	},
+	{
+		"Id": "food",
+		"Key": "Food",
+		"Type": "TechnologyFields",
+		"Parent": "",
+		"Bitmask": 0,
+		"TypeDesc": {
+			"de": "Food & Health",
+			"en": "Food & Health",
+			"it": "Food & Health"
 		}
 	}
 ]


### PR DESCRIPTION
We have removed the address field and the find button from the contact details screen. On top of that, the footer buttons will expand to fill the available width (e.g. if only the e-mail is available, the e-mail button will fill the entire width).

Also, the locally cached filters have been updated with the addition of the Public Engagement on. The app will stil use the remotely fetched ones, if available.